### PR TITLE
Fix dependency with grunt-lib-contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   "scripts": {
     "test": "grunt --verbose"
   },
-  "devDependencies": {
-    "grunt": "~0.3.17",
+  "dependencies": {
     "grunt-lib-contrib": "~0.3.1"
+  },
+  "devDependencies": {
+    "grunt": "~0.3.17"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Hi Erick!

thanks for the nice grunt plugin. It works great.

The only thing was that I got this error when I installed it with npm:

```
Loading "string-replace.js" tasks and helpers...ERROR
>> Error: Cannot find module 'grunt-lib-contrib'
<WARN> Task "string-replace" not found. Use --force to continue. </WARN>

Aborted due to warnings.
```

I fixed it in the meantime with running `npm install` in the plugin dir itself but this should not be necessary imo.

Thanks again
Andreas
