### PR TITLE
added successful logging like grunt-contrib-*

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "regex"
   ],
   "dependencies": {
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "chalk": "~0.4.0"
   }
 }

--- a/tasks/lib/string-replace.js
+++ b/tasks/lib/string-replace.js
@@ -6,7 +6,8 @@
  * Licensed under the MIT license.
  */
 var util = require('util'),
-  async = require('async');
+  async = require('async'),
+  chalk = require('chalk');
 
 exports.init = function(grunt) {
   'use strict';
@@ -61,6 +62,7 @@ exports.init = function(grunt) {
         content = grunt.file.read(src);
         content = exports.multi_str_replace(content, replacements);
         grunt.file.write(dest, content);
+        grunt.log.writeln('File ' + chalk.cyan(dest) + ' created.');
 
         return src_done();
       }, files_done);


### PR DESCRIPTION
I've added logging information if a file was successful changed/created in the same style as grunt-contrib-\* plugins (e.g. https://github.com/gruntjs/grunt-contrib-less/blob/master/tasks/less.js#L79).
